### PR TITLE
npe fix

### DIFF
--- a/feature/log-parser/anime/src/commonMain/kotlin/ru/vladislavsumin/feature/logParser/anime/domain/AnimeLogParser.kt
+++ b/feature/log-parser/anime/src/commonMain/kotlin/ru/vladislavsumin/feature/logParser/anime/domain/AnimeLogParser.kt
@@ -39,9 +39,11 @@ internal class AnimeLogParser : LogParser {
         names.forEach {
             zip.getInputStream(zip.getEntry(it)).use { internalZipStream ->
                 ZipInputStream(internalZipStream).use { zipStream ->
-                    zipStream.nextEntry!!
-                    val lines = zipStream.bufferedReader().lineSequence()
-                    parseLines(lines, result)
+                    val next = zipStream.nextEntry
+                    if (next != null) {
+                        val lines = zipStream.bufferedReader().lineSequence()
+                        parseLines(lines, result)
+                    }
                 }
             }
         }


### PR DESCRIPTION
```
java.lang.NullPointerException
	at ru.vladislavsumin.feature.logParser.anime.domain.AnimeLogParser.parseZip(AnimeLogParser.kt:42)
	at ru.vladislavsumin.feature.logParser.anime.domain.AnimeLogParser.parseLog(AnimeLogParser.kt:27)
	at ru.vladislavsumin.feature.logViewer.domain.logs.LogsInteractorImpl$loadLogs$1$1.invokeSuspend(LogsInteractor.kt:89)
	at ru.vladislavsumin.feature.logViewer.domain.logs.LogsInteractorImpl$loadLogs$1$1.invoke(LogsInteractor.kt)
	at ru.vladislavsumin.feature.logViewer.domain.logs.LogsInteractorImpl$loadLogs$1$1.invoke(LogsInteractor.kt)
	at kotlinx.coroutines.flow.FlowKt__MergeKt$mapLatest$1.invokeSuspend(Merge.kt:213)
	at kotlinx.coroutines.flow.FlowKt__MergeKt$mapLatest$1.invoke(Merge.kt)
	at kotlinx.coroutines.flow.FlowKt__MergeKt$mapLatest$1.invoke(Merge.kt)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1$2.invokeSuspend(Merge.kt:30)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1$2.invoke(Merge.kt)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1$2.invoke(Merge.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startCoroutineUndispatched(Undispatched.kt:20)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:360)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:53)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:44)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1.emit(Merge.kt:29)
	at kotlinx.coroutines.flow.StateFlowImpl.collect(StateFlow.kt:401)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3.invokeSuspend(Merge.kt:23)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3.invoke(Merge.kt)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3.invoke(Merge.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndspatched(Undispatched.kt:66)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:43)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:286)
	at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest.flowCollect(Merge.kt:21)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperator.collectTo$suspendImpl(ChannelFlow.kt:153)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperator.collectTo(ChannelFlow.kt)
	at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend(ChannelFlow.kt:56)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@35a19d6a, Dispatchers.IO]
```
